### PR TITLE
Add XAttr to Link struct

### DIFF
--- a/link_types.go
+++ b/link_types.go
@@ -34,6 +34,7 @@ type Link struct {
 	NodePassphrase          string // The passphrase used to unlock the NodeKey, encrypted by the owning Link/Share keyring.
 	NodePassphraseSignature string
 	SignatureEmail          string // Signature email for the NodePassphraseSignature
+	XAttr                   string // Modification time and size from the file system
 
 	FileProperties   *FileProperties
 	FolderProperties *FolderProperties


### PR DESCRIPTION
This simply adds an `XAttr` field to the `Link` struct, as the JSON response for links (in e.g. `ListChildren()`) contains such a field, and it can be used to obtain the size and modification time of the original plaintext (not encrypted) file without further API calls, which can offer some big performance improvements (ref. rclone/rclone#8058).

From my tests, it exactly matches the `XAttr` field of the active revision obtained with `ListRevisions()`.

(Side note: The active revision data included in the link JSON has an empty `XAttr` field, which may seem a little odd, but presumably it's because it would be redundant with the link's `XAttr` field, so there's no need to repeat it.)